### PR TITLE
feat(data-fetcher): pass store to fetch trigger

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     * [Register with the Hapi server](#register-with-the-hapi-server)
     * [Optional custom renderer that passes blankie (optional to provide yourself) nonces as a prop](#optional-custom-renderer-that-passes-blankie-optional-to-provide-yourself-nonces-as-a-prop)
   * [Dependencies for you to provide](#dependencies-for-you-to-provide)
+  * [Redial fetch trigger arguments](#redial-fetch-trigger-arguments)
 * [Contribution](#contribution)
   * [Install dependencies](#install-dependencies)
   * [Verification](#verification)
@@ -127,13 +128,14 @@ required.
 * `render`: _optional_ custom renderer to replace the default renderer. Passed `defaultRenderer` and `request` as arguments so additional props can be passed to the defaultRenderer, potentially from the request.
 
 ### Redial fetch trigger arguments
+
 * `params`: pass-through of react-router params taken from the path
 * `dispatch`: redux store [dispatch](https://redux.js.org/api/store/#dispatchaction) method
 * `state`: current state of the redux store
 * `getState`: [method](https://redux.js.org/api/store/#getstate) to get the
-latest state of the redux store
+  latest state of the redux store
 * `store`: the raw redux store. WARNING: this should only be used for unique
-circumstances (e.g., creating a custom subscription to the store)
+  circumstances (e.g., creating a custom subscription to the store)
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -134,8 +134,8 @@ required.
 * `state`: current state of the redux store
 * `getState`: [method](https://redux.js.org/api/store/#getstate) to get the
   latest state of the redux store
-* `store`: the raw redux store. WARNING: this should only be used for unique
-  circumstances (e.g., creating a custom subscription to the store)
+* `store`: the raw redux store. :warning: WARNING: this should only be used for
+  unique circumstances (e.g., creating a custom subscription to the store)
 
 ## Contribution
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ to direct all `text/html` requests to this `/html` route.
 In addition, [redial](https://github.com/markdalgleish/redial) `fetch` hooks
 will be triggered and rendering will wait for all related requests to complete.
 This enables populating the data store based on the components that are mounted
-for the current route.
+for the current route. See [redial arguments](#redial-fetch-trigger-arguments)
+for the list of arguments supplied to triggered fetches.
 
 ### Example
 
@@ -124,6 +125,15 @@ required.
   component so that your component can inject it into the context through a
   provider component.
 * `render`: _optional_ custom renderer to replace the default renderer. Passed `defaultRenderer` and `request` as arguments so additional props can be passed to the defaultRenderer, potentially from the request.
+
+### Redial fetch trigger arguments
+* `params`: pass-through of react-router params taken from the path
+* `dispatch`: redux store [dispatch](https://redux.js.org/api/store/#dispatchaction) method
+* `state`: current state of the redux store
+* `getState`: [method](https://redux.js.org/api/store/#getstate) to get the
+latest state of the redux store
+* `store`: the raw redux store. WARNING: this should only be used for unique
+circumstances (e.g., creating a custom subscription to the store)
 
 ## Contribution
 

--- a/src/data-fetcher-test.js
+++ b/src/data-fetcher-test.js
@@ -23,7 +23,7 @@ suite('data fetcher', () => {
     const getState = sinon.stub().returns(state);
     const renderProps = {...any.simpleObject(), components, params};
     const store = {...any.simpleObject(), dispatch, getState};
-    redial.trigger.withArgs('fetch', components, {params, dispatch, state, getState}).resolves();
+    redial.trigger.withArgs('fetch', components, {params, dispatch, state, getState, store}).resolves();
 
     return assert.isFulfilled(fetchData({renderProps, store}));
   });

--- a/src/data-fetcher.js
+++ b/src/data-fetcher.js
@@ -7,6 +7,7 @@ export default function ({renderProps, store}) {
     params: renderProps.params,
     dispatch: store.dispatch,
     state: getState(),
-    getState
+    getState,
+    store
   });
 }


### PR DESCRIPTION
- in some circumstances a consumer needs direct access to the store (e.g., creating a custom subscription) so we now provide this. this should only be used when absolutely needed.