### PR TITLE
Allow node 12 or higher, not strictly higher than node 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "example/"
   ],
   "engines": {
-    "node": ">12"
+    "node": ">=12"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
Removes this warning when on node 12:

```bash
npm WARN notsup Unsupported engine for @travi/hapi-react-router@6.2.2: wanted: {"node":">12"} (current: {"node":"12.19.0","npm":"6.14.8"})
```